### PR TITLE
bugfix: Cast build paths to str before setuputils Extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -265,11 +265,11 @@ if enable_aot:
         "csrc/group_gemm_e4m3_bf16_sm90.cu",
         "csrc/group_gemm_e5m2_bf16_sm90.cu",
     ]
-    decode_sources = list(gen_dir.glob("*decode_head*.cu"))
+    decode_sources = [str(path) for path in gen_dir.glob("*decode_head*.cu")]
     prefill_sources = [
-        f for f in gen_dir.glob("*prefill_head*.cu") if "_sm90" not in f.name
+        str(f) for f in gen_dir.glob("*prefill_head*.cu") if "_sm90" not in f.name
     ]
-    prefill_sm90_sources = list(gen_dir.glob("*prefill_head*_sm90.cu"))
+    prefill_sm90_sources = [str(path) for path in gen_dir.glob("*prefill_head*_sm90.cu")]
     ext_modules = [
         torch_cpp_ext.CUDAExtension(
             name="flashinfer.flashinfer_kernels",


### PR DESCRIPTION
Before, when building wheel with AOT enabled:
```
...
    return _build_backend().build_wheel(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 415, in build_wheel
    return self._build_with_temp_dir(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 397, in _build_with_temp_dir
    self.run_setup()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 313, in run_setup
    exec(code, locals())
  File "<string>", line 275, in <module>
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/cpp_extension.py", line 1207, in CUDAExtension
    return setuptools.Extension(name, sources, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/extension.py", line 133, in __init__
    super().__init__(name, sources, *args, **kw)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/extension.py", line 111, in __init__
    raise AssertionError("'sources' must be a list of strings")
AssertionError: 'sources' must be a list of strings
...
```
Due to `setuptools/_distutils/extension.py`:
```
...
        if not isinstance(name, str):
            raise AssertionError("'name' must be a string")
        if not (isinstance(sources, list) and all(isinstance(v, str) for v in sources)):
            raise AssertionError("'sources' must be a list of strings")
...
```